### PR TITLE
Fix bug in failure reporting

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -45,7 +45,7 @@ runs:
         api-key: ${{ steps.set_key.outputs.key }}
         run-tests: true
 
-    - if: github.repository_owner == 'getsentry' && ${{ failure() }}
+    - if: github.repository_owner == 'getsentry' && failure()
       name: 'Handle errors'
       shell: bash
       run: |


### PR DESCRIPTION
It seems the error message is being emitted even when there is no failure in a previous step:

https://github.com/getsentry/sentry-docs/runs/5817258711?check_suite_focus=true#step:2:857

[Expression docs](https://docs.github.com/en/actions/learn-github-actions/expressions)

Manually tested in https://github.com/getsentry/sentry-docs/pull/4902:

- [expected success](https://github.com/getsentry/sentry-docs/runs/5835097717?check_suite_focus=true#step:2:852)
- [expected failure](https://github.com/getsentry/sentry-docs/runs/5835003250?check_suite_focus=true#step:2:875)