### PR TITLE
Update action to use the default branch

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,13 +34,13 @@ runs:
 
     - if: github.repository_owner == 'getsentry'
       name: 'Run FOSSA Scan'
-      uses: fossas/fossa-action@5913e730490ebf75ae47b59687b7e590289eed92
+      uses: fossas/fossa-action@main
       with:
         api-key: ${{ steps.set_key.outputs.key }}
 
     - if: github.repository_owner == 'getsentry'
       name: 'Run FOSSA Test'
-      uses: fossas/fossa-action@5913e730490ebf75ae47b59687b7e590289eed92
+      uses: fossas/fossa-action@main
       with:
         api-key: ${{ steps.set_key.outputs.key }}
         run-tests: true


### PR DESCRIPTION
Default branch should already have the fixes for using `fossa test`.