### PR TITLE
ref(ci): fix set-output / set-state deprecation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ runs:
         # See also: https://docs.fossa.com/docs/api-reference#api-tokens
 
         FALLBACK="9fc50c40b136c68873ad05aec573cf3e"
-        echo "::set-output name=key::${PREFERRED:-$FALLBACK}"
+        echo "key=${PREFERRED:-$FALLBACK}" >> "$GITHUB_OUTPUT"
 
         echo "Turned off for now, #inc-187"
         #    - if: github.repository_owner == 'getsentry'


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Committed via https://github.com/asottile/all-repos