### PR TITLE
Re-enable fossa

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -63,7 +63,7 @@ runs:
         api-key: ${{ steps.set_key.outputs.key }}
         run-tests: true
 
-    - if: failure()
+    - if: github.repository_owner == 'getsentry' && failure()
       name: 'Handle errors'
       shell: bash
       run: |

--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,18 @@ runs:
       with:
         api-key: ${{ steps.set_key.outputs.key }}
 
+    - if: github.repository_owner == 'getsentry' && steps.analyze.outcome == 'failure'
+      name: 'Send error to Sentry on FOSSA scan failure'
+      shell: bash
+      env:
+        SENTRY_URL: https://self-hosted.getsentry.net/
+        SENTRY_ORG: self-hosted
+        SENTRY_PROJECT: test
+        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_TOKEN }}
+      run: |
+        curl -sL https://sentry.io/get-cli/ | sh
+        sentry-cli send-event -m "FOSSA scan failure" -e repo:$GITHUB_REPOSITORY actor:$GITHUB_ACTOR branch:$GITHUB_REF_NAME event_name:$GITHUB_EVENT_NAME url:'$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID'
+
       # We want to use steps.<step_id>.outcome here since it is the result of a completed
       # step before continue-on-error is applied.
     - if: github.repository_owner == 'getsentry' && steps.analyze.outcome == 'success'

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,7 @@ runs:
   using: "composite"
   steps:
     - if: github.repository_owner != 'getsentry'
+      shell: bash
       run: echo "This action should only run on getsentry repos" && exit 1
 
     - name: 'Pick a FOSSA API key'

--- a/action.yml
+++ b/action.yml
@@ -34,12 +34,17 @@ runs:
 
     - if: github.repository_owner == 'getsentry'
       name: 'Run FOSSA Scan'
+      id: analyze
+      continue-on-error: true
       uses: fossas/fossa-action@5913e730490ebf75ae47b59687b7e590289eed92
       with:
         api-key: ${{ steps.set_key.outputs.key }}
 
-    - if: github.repository_owner == 'getsentry'
+      # We want to use steps.<step_id>.outcome here since it is the result of a completed
+      # step before continue-on-error is applied.
+    - if: github.repository_owner == 'getsentry' && steps.analyze.outcome == 'success'
       name: 'Run FOSSA Test'
+      id: test
       uses: fossas/fossa-action@5913e730490ebf75ae47b59687b7e590289eed92
       with:
         api-key: ${{ steps.set_key.outputs.key }}

--- a/action.yml
+++ b/action.yml
@@ -2,6 +2,7 @@ name: "Enforce License Compliance"
 inputs:
   fossa_api_key:
     required: false
+secrets: inherit
 runs:
   using: "composite"
   steps:
@@ -47,10 +48,11 @@ runs:
         SENTRY_URL: https://self-hosted.getsentry.net/
         SENTRY_ORG: self-hosted
         SENTRY_PROJECT: test
-        SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_TOKEN }}
+        SENTRY_DSN: https://0bc733fd07014f73a703d97ab5452ae2@self-hosted.getsentry.net/4
+        # SENTRY_AUTH_TOKEN: ${{ inputs.sentry_token }}
       run: |
         curl -sL https://sentry.io/get-cli/ | sh
-        sentry-cli send-event -m "FOSSA scan failure" -e repo:$GITHUB_REPOSITORY actor:$GITHUB_ACTOR branch:$GITHUB_REF_NAME event_name:$GITHUB_EVENT_NAME url:'$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID'
+        sentry-cli send-event -m "FOSSA scan failure" -e repo:$GITHUB_REPOSITORY -e actor:$GITHUB_ACTOR -e branch:$GITHUB_REF_NAME -e event_name:$GITHUB_EVENT_NAME -e url:$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
 
       # We want to use steps.<step_id>.outcome here since it is the result of a completed
       # step before continue-on-error is applied.

--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,6 @@ name: "Enforce License Compliance"
 inputs:
   fossa_api_key:
     required: false
-secrets: inherit
 runs:
   using: "composite"
   steps:
@@ -49,7 +48,6 @@ runs:
         SENTRY_ORG: self-hosted
         SENTRY_PROJECT: test
         SENTRY_DSN: https://0bc733fd07014f73a703d97ab5452ae2@self-hosted.getsentry.net/4
-        # SENTRY_AUTH_TOKEN: ${{ inputs.sentry_token }}
       run: |
         curl -sL https://sentry.io/get-cli/ | sh
         sentry-cli send-event -m "FOSSA scan failure" -e repo:$GITHUB_REPOSITORY -e actor:$GITHUB_ACTOR -e branch:$GITHUB_REF_NAME -e event_name:$GITHUB_EVENT_NAME -e url:$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID

--- a/action.yml
+++ b/action.yml
@@ -28,31 +28,30 @@ runs:
         FALLBACK="9fc50c40b136c68873ad05aec573cf3e"
         echo "key=${PREFERRED:-$FALLBACK}" >> "$GITHUB_OUTPUT"
 
-        echo "Turned off for now, #inc-187"
-        #    - if: github.repository_owner == 'getsentry'
-        #      name: 'Checkout Code'
-        #      uses: actions/checkout@v2
-        #
-        #    - if: github.repository_owner == 'getsentry'
-        #      name: 'Run FOSSA Scan'
-        #      uses: fossas/fossa-action@5913e730490ebf75ae47b59687b7e590289eed92
-        #      with:
-        #        api-key: ${{ steps.set_key.outputs.key }}
-        #
-        #    - if: github.repository_owner == 'getsentry'
-        #      name: 'Run FOSSA Test'
-        #      uses: fossas/fossa-action@5913e730490ebf75ae47b59687b7e590289eed92
-        #      with:
-        #        api-key: ${{ steps.set_key.outputs.key }}
-        #        run-tests: true
-        #
-        #    - if: github.repository_owner == 'getsentry' && failure()
-        #      name: 'Handle errors'
-        #      shell: bash
-        #      run: |
-        #        echo
-        #        echo "🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 "
-        #        echo
-        #        echo "Eep! It seems that this PR introduces a license violation. Did you add any libraries? Do they use the GPL or some weird license? Am I a confused bot? If you need a hand, cc: @getsentry/open-source in a comment. 🙏"
-        #        echo
-        #        echo "🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 "
+    - if: github.repository_owner == 'getsentry'
+      name: 'Checkout Code'
+      uses: actions/checkout@v2
+
+    - if: github.repository_owner == 'getsentry'
+      name: 'Run FOSSA Scan'
+      uses: fossas/fossa-action@5913e730490ebf75ae47b59687b7e590289eed92
+      with:
+        api-key: ${{ steps.set_key.outputs.key }}
+
+    - if: github.repository_owner == 'getsentry'
+      name: 'Run FOSSA Test'
+      uses: fossas/fossa-action@5913e730490ebf75ae47b59687b7e590289eed92
+      with:
+        api-key: ${{ steps.set_key.outputs.key }}
+        run-tests: true
+
+    - if: github.repository_owner == 'getsentry' && failure()
+      name: 'Handle errors'
+      shell: bash
+      run: |
+        echo
+        echo "🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 "
+        echo
+        echo "Eep! It seems that this PR introduces a license violation. Did you add any libraries? Do they use the GPL or some weird license? Am I a confused bot? If you need a hand, cc: @getsentry/open-source in a comment. 🙏"
+        echo
+        echo "🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 "

--- a/action.yml
+++ b/action.yml
@@ -50,10 +50,11 @@ runs:
         SENTRY_DSN: https://0bc733fd07014f73a703d97ab5452ae2@self-hosted.getsentry.net/4
       run: |
         curl -sL https://sentry.io/get-cli/ | sh
-        sentry-cli send-event -m "FOSSA scan failure" -e repo:$GITHUB_REPOSITORY -e actor:$GITHUB_ACTOR -e branch:$GITHUB_REF_NAME -e event_name:$GITHUB_EVENT_NAME -e url:$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+        # Environment variables will automatically be sent, so we just want some minimal information
+        sentry-cli send-event -m "FOSSA scan failure in $GITHUB_REPOSITORY" -e url:$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
 
-      # We want to use steps.<step_id>.outcome here since it is the result of a completed
-      # step before continue-on-error is applied.
+      # We only want to run license compliance test if FOSSA scan succeeds. This is to unblock CI
+      # on FOSSA outages.
     - if: github.repository_owner == 'getsentry' && steps.analyze.outcome == 'success'
       name: 'Run FOSSA Test'
       id: test

--- a/action.yml
+++ b/action.yml
@@ -5,8 +5,10 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - if: github.repository_owner == 'getsentry' # kinda gross that we have to repeat this
-      name: 'Pick a FOSSA API key'
+    - if: github.repository_owner != 'getsentry'
+      run: echo "This action should only run on getsentry repos" && exit 1
+
+    - name: 'Pick a FOSSA API key'
       id: set_key
       shell: bash
       env:
@@ -28,19 +30,17 @@ runs:
         FALLBACK="9fc50c40b136c68873ad05aec573cf3e"
         echo "key=${PREFERRED:-$FALLBACK}" >> "$GITHUB_OUTPUT"
 
-    - if: github.repository_owner == 'getsentry'
-      name: 'Checkout Code'
+    - name: 'Checkout Code'
       uses: actions/checkout@v2
 
-    - if: github.repository_owner == 'getsentry'
-      name: 'Run FOSSA Scan'
+    - name: 'Run FOSSA Scan'
       id: analyze
       continue-on-error: true
       uses: fossas/fossa-action@5913e730490ebf75ae47b59687b7e590289eed92
       with:
         api-key: ${{ steps.set_key.outputs.key }}
 
-    - if: github.repository_owner == 'getsentry' && steps.analyze.outcome == 'failure'
+    - if: steps.analyze.outcome == 'failure'
       name: 'Send error to Sentry on FOSSA scan failure'
       shell: bash
       env:
@@ -55,7 +55,7 @@ runs:
 
       # We only want to run license compliance test if FOSSA scan succeeds. This is to unblock CI
       # on FOSSA outages.
-    - if: github.repository_owner == 'getsentry' && steps.analyze.outcome == 'success'
+    - if: steps.analyze.outcome == 'success'
       name: 'Run FOSSA Test'
       id: test
       uses: fossas/fossa-action@5913e730490ebf75ae47b59687b7e590289eed92
@@ -63,7 +63,7 @@ runs:
         api-key: ${{ steps.set_key.outputs.key }}
         run-tests: true
 
-    - if: github.repository_owner == 'getsentry' && failure()
+    - if: failure()
       name: 'Handle errors'
       shell: bash
       run: |


### PR DESCRIPTION
This re-enables FOSSA license compliance scans so that running FOSSA test will be skipped if the analysis fails.

> We recommend that if you don’t want to gate CI on FOSSA,  either
> - Add continue-on-error: true to the FOSSA action step, or
> - If you run FOSSA manually (using the CLI), you can do `fossa analyze || true` in a step

> I'm not sure if you run fossa test afterwards, but if you do I'd place some Actions logic to say if the analysis step failed then bypass the fossa test step.

Took the 1st recommendation from FOSSA devs here

This will not affect `getsentry/sentry` or `getsentry/getsentry` since the action in those repos is pinned to a commit