### PR TITLE
Parse logs for FOSSA action to determine actual license scan failures

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ runs:
 
         # FOSSA has two kinds of API keys (aka tokens), a full-privilege key
         # and a low-privilege "push-only" key. The practical difference is that
-        # the full key provides more feedback on `fossa test` failure. We have
+        # the full key provides more feedback on `fossa test` errors. We have
         # a full key stored in org-wide GitHub Secrets, but a) we can't access
         # it in an action, only in a workflow (hence the input here) and b) it
         # isn't available even in a workflow when run in a PR from a fork. If
@@ -35,7 +35,7 @@ runs:
     - name: 'Checkout Code'
       uses: actions/checkout@v2
 
-    - name: 'Run FOSSA Scan'
+    - name: 'Run `fossa analyze`'
       id: analyze
       continue-on-error: true
       env:
@@ -45,10 +45,10 @@ runs:
         exec &> >(tee -a "analyze_logs.txt")
         fossa analyze
 
-      # We only want to run license compliance test if FOSSA scan succeeds. This is to unblock CI
+      # We only want to run license compliance test if `fossa test` succeeds. This is to unblock CI
       # on FOSSA outages.
     - if: steps.analyze.outcome == 'success'
-      name: 'Run FOSSA Test'
+      name: 'Run `fossa test`'
       id: test
       continue-on-error: true
       env:
@@ -56,21 +56,19 @@ runs:
       shell: bash
       run: |
         exec &> >(tee -a "test_logs.txt")
-        # Set timeout to 10 minutes
-        fossa test --timeout 600
+        # Set timeout to 5 minutes
+        fossa test --timeout 300
 
     - if: steps.analyze.outcome == 'failure' || steps.test.outcome == 'failure'
-      name: 'Send error to Sentry on FOSSA scan failure'
+      name: 'Send error to Sentry on `fossa-cli` errors'
       shell: bash
       env:
-        SENTRY_URL: https://self-hosted.getsentry.net/
-        SENTRY_ORG: self-hosted
-        SENTRY_DSN: https://0bc733fd07014f73a703d97ab5452ae2@self-hosted.getsentry.net/4
+        SENTRY_DSN: https://decbca863c554db095624ede8a83310c@o1.ingest.sentry.io/4505031352713216
       run: |
         if [[ ${{ steps.analyze.outcome }} == 'failure' ]]; then
           curl -sL https://sentry.io/get-cli/ | sh
           # Environment variables will automatically be sent, so we just want some minimal information
-          sentry-cli send-event -m "FOSSA scan failure" -t repo:$GITHUB_REPOSITORY -e url:$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID --logfile analyze_logs.txt
+          sentry-cli send-event -m "FOSSA analyze error" -t repo:$GITHUB_REPOSITORY -e url:$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID --logfile analyze_logs.txt
           exit 0
         fi
         if grep -q "The scan has revealed issues. Number of issues found:" test_logs.txt; then
@@ -83,4 +81,4 @@ runs:
           exit 1
         fi
         curl -sL https://sentry.io/get-cli/ | sh
-        sentry-cli send-event -m "FOSSA test failure" -t repo:$GITHUB_REPOSITORY -e url:$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID --logfile test_logs.txt
+        sentry-cli send-event -m "FOSSA test error" -t repo:$GITHUB_REPOSITORY -e url:$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID --logfile test_logs.txt

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ runs:
       shell: bash
       run: echo "This action should only run on getsentry repos" && exit 1
 
-    - name: 'Pick a FOSSA API key'
+    - name: 'Pick a FOSSA API key and install FOSSA cli'
       id: set_key
       shell: bash
       env:
@@ -27,9 +27,9 @@ runs:
         # here in this file and gives us at least basic pass/fail.
         #
         # See also: https://docs.fossa.com/docs/api-reference#api-tokens
-
         FALLBACK="9fc50c40b136c68873ad05aec573cf3e"
         echo "key=${PREFERRED:-$FALLBACK}" >> "$GITHUB_OUTPUT"
+        curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash
 
     - name: 'Checkout Code'
       uses: actions/checkout@v2
@@ -37,9 +37,12 @@ runs:
     - name: 'Run FOSSA Scan'
       id: analyze
       continue-on-error: true
-      uses: fossas/fossa-action@5913e730490ebf75ae47b59687b7e590289eed92
-      with:
-        api-key: ${{ steps.set_key.outputs.key }}
+      env:
+        FOSSA_API_KEY: ${{ steps.set_key.outputs.key }}
+      shell: bash
+      run: |
+        exec &> >(tee -a "analyze_logs.txt")
+        fossa analyze
 
     - if: steps.analyze.outcome == 'failure'
       name: 'Send error to Sentry on FOSSA scan failure'
@@ -47,7 +50,6 @@ runs:
       env:
         SENTRY_URL: https://self-hosted.getsentry.net/
         SENTRY_ORG: self-hosted
-        SENTRY_PROJECT: test
         SENTRY_DSN: https://0bc733fd07014f73a703d97ab5452ae2@self-hosted.getsentry.net/4
       run: |
         curl -sL https://sentry.io/get-cli/ | sh
@@ -59,10 +61,12 @@ runs:
     - if: steps.analyze.outcome == 'success'
       name: 'Run FOSSA Test'
       id: test
-      uses: fossas/fossa-action@5913e730490ebf75ae47b59687b7e590289eed92
-      with:
-        api-key: ${{ steps.set_key.outputs.key }}
-        run-tests: true
+      env:
+        FOSSA_API_KEY: ${{ steps.set_key.outputs.key }}
+      shell: bash
+      run: |
+        exec &> >(tee -a "test_logs.txt")
+        fossa test
 
     - if: github.repository_owner == 'getsentry' && failure()
       name: 'Handle errors'

--- a/action.yml
+++ b/action.yml
@@ -66,8 +66,8 @@ runs:
         SENTRY_ORG: self-hosted
         SENTRY_DSN: https://0bc733fd07014f73a703d97ab5452ae2@self-hosted.getsentry.net/4
       run: |
-        curl -sL https://sentry.io/get-cli/ | sh
         if [[ ${{ steps.analyze.outcome }} == 'failure' ]]; then
+          curl -sL https://sentry.io/get-cli/ | sh
           # Environment variables will automatically be sent, so we just want some minimal information
           sentry-cli send-event -m "FOSSA scan failure" -t repo:$GITHUB_REPOSITORY -e url:$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID --logfile analyze_logs.txt
           exit 0
@@ -81,5 +81,5 @@ runs:
           echo "🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 "
           exit 1
         fi
+        curl -sL https://sentry.io/get-cli/ | sh
         sentry-cli send-event -m "FOSSA test failure" -t repo:$GITHUB_REPOSITORY -e url:$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID --logfile test_logs.txt
-        exit 0

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ runs:
         # See also: https://docs.fossa.com/docs/api-reference#api-tokens
         FALLBACK="9fc50c40b136c68873ad05aec573cf3e"
         echo "key=${PREFERRED:-$FALLBACK}" >> "$GITHUB_OUTPUT"
-        # Install v3.7.4 version of fossa-cli
+        # Install specific version of fossa-cli to guarantee stability of parsing fossa job outputs
         curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/v3.7.5/install-latest.sh | bash
 
     - name: 'Checkout Code'

--- a/action.yml
+++ b/action.yml
@@ -69,7 +69,7 @@ runs:
           curl -sL https://sentry.io/get-cli/ | sh
           # Environment variables will automatically be sent, so we just want some minimal information
           error_msg=$(cat analyze_logs.txt | grep -zoP '(?<=>>> Relevant errors\n\n    Error\n\n      ).*?(?=\n)' || echo 'unknown error message')
-          sentry-cli send-event -m "FOSSA analyze error: $error_msg" -t repo:$GITHUB_REPOSITORY -e url:$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID --logfile analyze_logs.txt
+          sentry-cli send-event -m "analyze: $error_msg" -t repo:$GITHUB_REPOSITORY -e url:$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID --logfile analyze_logs.txt
           exit 0
         fi
         if grep -q "The scan has revealed issues. Number of issues found:" test_logs.txt; then
@@ -83,4 +83,4 @@ runs:
         fi
         curl -sL https://sentry.io/get-cli/ | sh
         error_msg=$(cat test_logs.txt | grep -zoP '(?<=>>> Relevant errors\n\n    Error\n\n      ).*?(?=\n)' || echo 'unknown error message')
-        sentry-cli send-event -m "FOSSA test error: $error_msg" -t repo:$GITHUB_REPOSITORY -e url:$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID --logfile test_logs.txt
+        sentry-cli send-event -m "test: $error_msg" -t repo:$GITHUB_REPOSITORY -e url:$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID --logfile test_logs.txt

--- a/action.yml
+++ b/action.yml
@@ -56,7 +56,8 @@ runs:
       shell: bash
       run: |
         exec &> >(tee -a "test_logs.txt")
-        fossa test
+        # Set timeout to 10 minutes
+        fossa test --timeout 600
 
     - if: steps.analyze.outcome == 'failure' || steps.test.outcome == 'failure'
       name: 'Send error to Sentry on FOSSA scan failure'

--- a/action.yml
+++ b/action.yml
@@ -72,8 +72,7 @@ runs:
           sentry-cli send-event -m "FOSSA scan failure" -t repo:$GITHUB_REPOSITORY -e url:$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID --logfile analyze_logs.txt
           exit 0
         fi
-        test_logs=$(cat test_logs.txt)
-        if [[ "$test_logs =~ /.*The scan has revealed issues. Number of issues found:.*/gm ]]; then
+        if grep -q "The scan has revealed issues. Number of issues found:" test_logs.txt; then
           echo
           echo "🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 "
           echo

--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ runs:
         FALLBACK="9fc50c40b136c68873ad05aec573cf3e"
         echo "key=${PREFERRED:-$FALLBACK}" >> "$GITHUB_OUTPUT"
         # Install v3.7.4 version of fossa-cli
-        curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/v3.7.4/install-latest.sh | bash
+        curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/v3.7.5/install-latest.sh | bash
 
     - name: 'Checkout Code'
       uses: actions/checkout@v2

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ runs:
 
         # FOSSA has two kinds of API keys (aka tokens), a full-privilege key
         # and a low-privilege "push-only" key. The practical difference is that
-        # the full key provides more feedback on `fossa test` errors. We have
+        # the full key provides more feedback on `fossa test` failure. We have
         # a full key stored in org-wide GitHub Secrets, but a) we can't access
         # it in an action, only in a workflow (hence the input here) and b) it
         # isn't available even in a workflow when run in a PR from a fork. If
@@ -56,7 +56,7 @@ runs:
       shell: bash
       run: |
         exec &> >(tee -a "test_logs.txt")
-        # Set timeout to 5 minutes
+        # Set timeout to 5 minutes (default of 60 minutes is waaaay too long to block CI)
         fossa test --timeout 300
 
     - if: steps.analyze.outcome == 'failure' || steps.test.outcome == 'failure'
@@ -68,7 +68,8 @@ runs:
         if [[ ${{ steps.analyze.outcome }} == 'failure' ]]; then
           curl -sL https://sentry.io/get-cli/ | sh
           # Environment variables will automatically be sent, so we just want some minimal information
-          sentry-cli send-event -m "FOSSA analyze error" -t repo:$GITHUB_REPOSITORY -e url:$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID --logfile analyze_logs.txt
+          error_msg=$(cat analyze_logs.txt | grep -zoP '(?<=>>> Relevant errors\n\n    Error\n\n      ).*?(?=\n)' || echo 'unknown error message')
+          sentry-cli send-event -m "FOSSA analyze error: $error_msg" -t repo:$GITHUB_REPOSITORY -e url:$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID --logfile analyze_logs.txt
           exit 0
         fi
         if grep -q "The scan has revealed issues. Number of issues found:" test_logs.txt; then
@@ -81,4 +82,5 @@ runs:
           exit 1
         fi
         curl -sL https://sentry.io/get-cli/ | sh
-        sentry-cli send-event -m "FOSSA test error" -t repo:$GITHUB_REPOSITORY -e url:$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID --logfile test_logs.txt
+        error_msg=$(cat test_logs.txt | grep -zoP '(?<=>>> Relevant errors\n\n    Error\n\n      ).*?(?=\n)' || echo 'unknown error message')
+        sentry-cli send-event -m "FOSSA test error: $error_msg" -t repo:$GITHUB_REPOSITORY -e url:$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID --logfile test_logs.txt

--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,8 @@ runs:
         # See also: https://docs.fossa.com/docs/api-reference#api-tokens
         FALLBACK="9fc50c40b136c68873ad05aec573cf3e"
         echo "key=${PREFERRED:-$FALLBACK}" >> "$GITHUB_OUTPUT"
-        curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash
+        # Install v3.7.4 version of fossa-cli
+        curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/v3.7.4/install-latest.sh | bash
 
     - name: 'Checkout Code'
       uses: actions/checkout@v2
@@ -44,7 +45,20 @@ runs:
         exec &> >(tee -a "analyze_logs.txt")
         fossa analyze
 
-    - if: steps.analyze.outcome == 'failure'
+      # We only want to run license compliance test if FOSSA scan succeeds. This is to unblock CI
+      # on FOSSA outages.
+    - if: steps.analyze.outcome == 'success'
+      name: 'Run FOSSA Test'
+      id: test
+      continue-on-error: true
+      env:
+        FOSSA_API_KEY: ${{ steps.set_key.outputs.key }}
+      shell: bash
+      run: |
+        exec &> >(tee -a "test_logs.txt")
+        fossa test
+
+    - if: steps.analyze.outcome == 'failure' || steps.test.outcome == 'failure'
       name: 'Send error to Sentry on FOSSA scan failure'
       shell: bash
       env:
@@ -53,28 +67,20 @@ runs:
         SENTRY_DSN: https://0bc733fd07014f73a703d97ab5452ae2@self-hosted.getsentry.net/4
       run: |
         curl -sL https://sentry.io/get-cli/ | sh
-        # Environment variables will automatically be sent, so we just want some minimal information
-        sentry-cli send-event -m "FOSSA scan failure in $GITHUB_REPOSITORY" -e url:$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
-
-      # We only want to run license compliance test if FOSSA scan succeeds. This is to unblock CI
-      # on FOSSA outages.
-    - if: steps.analyze.outcome == 'success'
-      name: 'Run FOSSA Test'
-      id: test
-      env:
-        FOSSA_API_KEY: ${{ steps.set_key.outputs.key }}
-      shell: bash
-      run: |
-        exec &> >(tee -a "test_logs.txt")
-        fossa test
-
-    - if: github.repository_owner == 'getsentry' && failure()
-      name: 'Handle errors'
-      shell: bash
-      run: |
-        echo
-        echo "🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 "
-        echo
-        echo "Eep! It seems that this PR introduces a license violation. Did you add any libraries? Do they use the GPL or some weird license? Am I a confused bot? If you need a hand, cc: @getsentry/open-source in a comment. 🙏"
-        echo
-        echo "🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 "
+        if [[ ${{ steps.analyze.outcome }} == 'failure' ]]; then
+          # Environment variables will automatically be sent, so we just want some minimal information
+          sentry-cli send-event -m "FOSSA scan failure" -t repo:$GITHUB_REPOSITORY -e url:$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID --logfile analyze_logs.txt
+          exit 0
+        fi
+        test_logs=$(cat test_logs.txt)
+        if [[ "$test_logs =~ /.*The scan has revealed issues. Number of issues found:.*/gm ]]; then
+          echo
+          echo "🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 "
+          echo
+          echo "Eep! It seems that this PR introduces a license violation. Did you add any libraries? Do they use the GPL or some weird license? Am I a confused bot? If you need a hand, cc: @getsentry/open-source in a comment. 🙏"
+          echo
+          echo "🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 🛑 "
+          exit 1
+        fi
+        sentry-cli send-event -m "FOSSA test failure" -t repo:$GITHUB_REPOSITORY -e url:$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID --logfile test_logs.txt
+        exit 0


### PR DESCRIPTION
This parses FOSSA scan logs to check for error or specific license scanning failure. closes https://github.com/getsentry/team-ospo/issues/124

FOSSA connection failure still passing CI: https://github.com/getsentry/sentry/actions/runs/4682991144/attempts/1
FOSSA connection license scan failure failing CI: https://github.com/getsentry/sentry/actions/runs/4692294461/attempts/1
FOSSA license scan success passing CI: https://github.com/getsentry/sentry/actions/runs/4702538858/jobs/8342542104?pr=47273
FOSSA timeout but still passing CI: https://github.com/getsentry/sentry/actions/runs/4702538858/jobs/8339925767?pr=47273