### PR TITLE
Use checkout v3

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ runs:
         curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/v3.7.8/install-latest.sh | bash -s -- v3.7.8
 
     - name: 'Checkout Code'
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: 'Run `fossa analyze`'
       id: analyze


### PR DESCRIPTION
This has the node 12 -> node 16 fix.

Once this lands, we need to update: enforce-license-compliance.yml in getsentry (and sentry if its used)