### PR TITLE
feat: Add `skip_checkout` input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,6 +2,10 @@ name: "Enforce License Compliance"
 inputs:
   fossa_api_key:
     required: false
+  skip_checkout:
+    description: 'Skip running actions/checkout'
+    required: false
+    default: 'false'
 runs:
   using: "composite"
   steps:
@@ -34,6 +38,7 @@ runs:
         curl -H 'Cache-Control: no-cache' "https://raw.githubusercontent.com/fossas/fossa-cli/$VERSION/install-latest.sh" | bash -s -- "$VERSION"
 
     - name: 'Checkout Code'
+      if: inputs.skip_checkout != 'true'
       uses: actions/checkout@v3
 
     - name: 'Run `fossa analyze`'


### PR DESCRIPTION
`fossa-cli` was consistently failing in https://github.com/getsentry/sentry-java because `fossa-cli` doesn't support Gradle with the configuration cache enabled.
See https://github.com/fossas/fossa-cli/issues/872
Until this is fixed upstream, we would like to have a way to still run this action in our CI.

A workaround on our side would be to run `actions/checkout`, edit `gradle.properties` in the workflow, and only then run this action --  it's not possible to disable the cache otherwise, as other ways to configure gradle, such as environment variables, have a lower priority than what is specified in the `gradle.properties`.

To be able to work around this, we need to have a way to skip running `actions/checkout` in this action, otherwise our edits to `gradle.properties` would be overwritten.